### PR TITLE
False Companion Pets

### DIFF
--- a/DataFunctions.lua
+++ b/DataFunctions.lua
@@ -34,6 +34,17 @@ Data.ItemCategories = {
 	DrakewatcherManuscript = 196970,
 }
 
+-- Merchant items with wrong Blizz classifications
+-- 'Misc: Companion Pets' that aren't pets (but toys, except 174925)
+local falsePets = {
+	[37460] = true, -- Rope Pet Leash (verified): Toy
+	[44820] = true, -- Red Ribbon Pet Leash (verified): Toy
+	[174995] = true, -- Void Tendril Pet Leash (verified): Toy
+	[174925] = true, -- Void Tendril Pet Leash (verified): One-time use item
+	[71137] = true, -- Brewfest Keg Pony (wowhead); Brewfest event only: Toy
+	[75042] = true, -- Flimsy Yellow Balloon (wowhead); DMF event only: Toy
+}
+
 -- Sync updated Merchant information
 function Data:UpdateMerchant()
 	SetMerchantFilter(LE_LOOT_FILTER_ALL)
@@ -222,7 +233,7 @@ function Data:GetCollectable(link, itemdata)
 	elseif class == Enum.ItemClass.Miscellaneous then
 
 		-- This is a pet, let's see if we know it and how many we have
-		if subclass == Enum.ItemMiscellaneousSubclass.CompanionPet then
+		if subclass == Enum.ItemMiscellaneousSubclass.CompanionPet and not falsePets[itemid] then
 			-- This field could move; look for speciesID index
 			local petinfo = { C_PetJournal.GetPetInfoByItemID(itemid) }
 			local count, max = C_PetJournal.GetNumCollectedInfo(petinfo[13])


### PR DESCRIPTION
This is for WoW Retail.

There are some vendor items in the game that are listed by Blizz as "Miscellaneous: Companion Pets", but they aren't. (Most of them are toys.) These throw an error and mess up the merchant display (see my [Issue](https://github.com/kstange/MerchantPlus/issues/7)).

I have added a hardcoded table with the affected items IDs to DataFunctions.lua. These item IDs are then excluded from your `if subclass == Enum.ItemMiscellaneousSubclass.CompanionPet` condition further down.

In the comment after each table entry I have noted the item name and what it really is (most are Toys, one is a consumable one-time use item).

A "verified" means that I have verified the error (and the fix) in-game. 

A "wowhead" means that I have not verified it, because the item is only avalable with certain events. I found the items on wowhead, but it is very likely that they will produce the error too *if* they are listed as Companions in-game, since they are in fact Toys.

I have used [this filtered list \(Toys\)](https://www.wowhead.com/items/live-only:on?filter=216;1;0%230+14+18) on wowhead. It should be sorted by Type, with "Companions" at top. I have only considered items that are sold by merchants, not crafted things etc.

However, not everything on wowhead is true: For example the "Wind-Up Train Wrecker" (45057) Toy is listed as type "Companion" on wowhead, but in-game it is *correctly* listed as "Others", not as "Companion", and therefore does not produce any error. (Though, adding it to the table would do no harm, it's just not needed.)

Once the events are online (DMF and Brewfest), you should check if my 2 not verified ("wowhead") entries are really listed as Companions in the game.

I was only looking at Toys on wowhead, so it is quite possible that there are more false Companion Pets in-game, that are not Toys (like the Void Tendril Pet Leash one-time Consumable (174925), that I accidentally found in-game, not to be confused with the Toy (174995) of the same name and with the same problem).

Hope this helps.

– Tom
